### PR TITLE
make ShardedActorRegistry.INSTANCE final to enforce singleton

### DIFF
--- a/core/src/main/java/io/github/seonwkim/core/shard/ShardedActorRegistry.java
+++ b/core/src/main/java/io/github/seonwkim/core/shard/ShardedActorRegistry.java
@@ -16,7 +16,7 @@ public class ShardedActorRegistry {
     /**
      * Singleton instance of the registry. This instance can be used when a shared registry is needed.
      */
-    public static ShardedActorRegistry INSTANCE = new ShardedActorRegistry();
+    public static final ShardedActorRegistry INSTANCE = new ShardedActorRegistry();
 
     /**
      * Registers a sharded actor with the registry. The actor is indexed by its entity type key.


### PR DESCRIPTION
## Description
ShardedActorRegistry.INSTANCE was documented as providing a singleton instance, but the final keyword was missing, failing to guarantee singleton behavior

## Changes Made
Add final keyword to ShardedActorRegistry.INSTANCE

## Additional Context